### PR TITLE
Update image tag to v0.2.0

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: mumoshu/aws-ssm-agent:v0.1.0
+      - image: mumoshu/aws-ssm-agent:v0.2.0
         name: ssm-agent
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
noticed while using this tool

Docker image v0.2.0 has already been released, but DaemonSet manifest is not updated