### PR TITLE
Fix arn of policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Clone this repository and run:
 $ eksctl create cluster
 
 # Replace the role-name with the InstanceRole shown in `eksctl utils describe-stack`
-$ aws iam attach-role-policy --role-name eksctl-amazing-creature-154580785-NodeInstanceRole-RXNVQC8YTLP7 --policy-arn arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore
+$ aws iam attach-role-policy --role-name eksctl-amazing-creature-154580785-NodeInstanceRole-RXNVQC8YTLP7 --policy-arn arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
 
 $ kubectl apply -f daemonset.yaml
 


### PR DESCRIPTION
ARN is wrong. It should be this.

```console
$ aws iam get-policy --policy-arn arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
{
    "Policy": {
        "PolicyName": "AmazonSSMManagedInstanceCore",
        "PolicyId": "ANPAIXSHM2BNB2D3AXXRU",
        "Arn": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
        "Path": "/",
        "DefaultVersionId": "v2",
        "AttachmentCount": 3,
        "PermissionsBoundaryUsageCount": 0,
        "IsAttachable": true,
        "Description": "The policy for Amazon EC2 Role to enable AWS Systems Manager service core functionality.",
        "CreateDate": "2019-03-15T17:22:12Z",
        "UpdateDate": "2019-05-23T16:54:21Z"
    }
}
```