### PR TITLE
Don't require the eksctl directory to exist

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -101,4 +101,4 @@ spec:
       - name: etc-eksctl
         hostPath:
           path: /etc/eksctl
-          type: Directory
+          type: DirectoryOrCreate


### PR DESCRIPTION
If it doesn't just create, this daemon set will also
work on EKS clusters that weren't created through eksctl
this way.